### PR TITLE
fix: add `actualURL` property to GET /api/list (SOFIE-2781)

### DIFF
--- a/src/helpers/APIHelper.ts
+++ b/src/helpers/APIHelper.ts
@@ -139,6 +139,7 @@ export class APIHelper {
 			ctx.response.status = 200
 			ctx.body = `
 <a href="/api/status?apiKey=${this.config?.apiKey}">GET /api/status</a><br>
+<a href="/api/list?apiKey=${this.config?.apiKey}">GET /api/list</a><br>
 POST /api/playURL/:windowId body: {"url": "", "jsCode": "" }<br>
 POST /api/restart/:windowId<br>
 POST /api/stop/:windowId<br>
@@ -321,6 +322,7 @@ POST /api/execute/:windowId body: {"jsCode": "" }<br>
 			body: windows.map((w) => ({
 				id: w.id,
 				url: w.window.url,
+				actualUrl: w.window.getURL(),
 				statusCode: w.window.status.statusCode,
 				statusMessage: w.window.status.message,
 			})),

--- a/src/helpers/WindowHelper.ts
+++ b/src/helpers/WindowHelper.ts
@@ -276,7 +276,7 @@ export class WindowHelper extends EventEmitter {
 
 		this.emit('window-has-been-modified')
 	}
-	private getURL(): string {
+	public getURL(): string {
 		const windowUrl = this._url ?? this._config.defaultURL
 
 		if (this._sharedConfig.baseURL && !windowUrl.match(/^(?:[a-z+]+:)?\/\//i)) {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -71,6 +71,7 @@ export interface APIResponseList extends APIResponseBase {
 	body: {
 		id: string
 		url: string | null
+		actualUrl: string
 		statusCode: string
 		statusMessage: string
 	}[]


### PR DESCRIPTION
Before:
```
GET http://localhost:5270/api/list

[{"id":"default","url":null,"statusCode":"good","statusMessage":""}]

```
After:
```
GET http://localhost:5270/api/list

[{"id":"default","url":null,"actualUrl":"https://omni.se/","statusCode":"good","statusMessage":""}]

```
