### PR TITLE
feat: add allowedWebHIDDevices

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ Most properties of the `config.json`-file are also automatically updated when mo
 
 See [config.ts](src/lib/config.ts)
 
+### WebHID Auto-Approval
+
+To configure per-window WebHID device allowlists, see [docs/WebHID-Configuration.md](docs/WebHID-Configuration.md).
+
+An example config is available at [examples/config-with-webhid.json](examples/config-with-webhid.json).
+
 ## Tips for Running in Fullscreen Mode
 
 Here are some tips for when you want to display something in fullscreen and want to avoid

--- a/docs/WebHID-Configuration.md
+++ b/docs/WebHID-Configuration.md
@@ -1,0 +1,95 @@
+# WebHID Device Configuration
+
+This document explains how to configure Sofie Chef to automatically approve specific WebHID devices, eliminating the need to manually approve them each time the browser is restarted.
+
+## Configuration
+
+Add the `allowedWebHIDDevices` array to your window configuration in the Chef config file. Each device entry should specify the vendor ID and product ID, and optionally usage page and usage values.
+
+### Example Configuration
+
+```json
+{
+	"windows": {
+		"default": {
+			"width": 1280,
+			"height": 720,
+			"defaultURL": "https://example.com",
+			"allowedWebHIDDevices": [
+				{
+					"vendorId": 1133,
+					"productId": 49824,
+					"usagePage": 1,
+					"usage": 6
+				},
+				{
+					"vendorId": 1452,
+					"productId": 613
+				}
+			]
+		}
+	}
+}
+```
+
+### Device Properties
+
+- **vendorId** (required): The vendor ID of the HID device (decimal number)
+- **productId** (required): The product ID of the HID device (decimal number)
+- **usagePage** (optional): The HID usage page filter
+- **usage** (optional): The HID usage filter
+
+### Finding Device IDs
+
+You can find device IDs using several methods:
+
+#### Method 1: Browser DevTools Console
+
+When a WebHID device is connected, you can inspect it in the browser console:
+
+```javascript
+// List all connected HID devices
+navigator.hid.getDevices().then((devices) => {
+	devices.forEach((device) => {
+		console.log(`Vendor ID: ${device.vendorId} (0x${device.vendorId.toString(16)})`)
+		console.log(`Product ID: ${device.productId} (0x${device.productId.toString(16)})`)
+		console.log(`Usage Page: ${device.usagePage}`)
+		console.log(`Usage: ${device.usage}`)
+	})
+})
+```
+
+#### Method 2: System Tools
+
+**Windows:**
+
+- Device Manager → View → Devices by type → Human Interface Devices
+- Right-click device → Properties → Details → Hardware Ids
+
+**macOS:**
+
+- System Information → Hardware → USB
+- Look for vendor ID and product ID in the device details
+
+**Linux:**
+
+- `lsusb` command shows connected USB devices with vendor:product IDs
+
+### Important Notes
+
+1. **Decimal vs Hexadecimal**: The configuration uses decimal numbers, but device IDs are often displayed in hexadecimal. Convert hex values to decimal for the config.
+
+2. **Security**: Only add devices you trust, as approved devices will have full access to the web page without user confirmation.
+
+3. **Scope**: Device approval is per-window. Each window can have its own allowed device list.
+
+4. **Logging**: Chef will log when devices are auto-approved or denied, making it easier to debug configuration issues.
+
+### Troubleshooting
+
+If your device isn't being auto-approved:
+
+1. Check the Chef logs for WebHID permission messages
+2. Verify the vendor ID and product ID are correct and in decimal format
+3. Ensure the device is properly connected before loading the page
+4. Try omitting the optional `usagePage` and `usage` filters if specified

--- a/examples/config-with-webhid.json
+++ b/examples/config-with-webhid.json
@@ -1,0 +1,35 @@
+{
+	"freeze": false,
+	"apiPort": 5270,
+	"apiKey": "",
+	"windows": {
+		"main": {
+			"disable": false,
+			"x": 100,
+			"y": 100,
+			"width": 1920,
+			"height": 1080,
+			"fullScreen": false,
+			"onTop": false,
+			"frameless": false,
+			"displayDebug": false,
+			"defaultURL": "https://example.com/hid-test",
+			"defaultColor": "#000000",
+			"hideCursor": true,
+			"hideScrollbar": false,
+			"zoomFactor": 100,
+			"allowedWebHIDDevices": [
+				{
+					"vendorId": 1133,
+					"productId": 49824,
+					"usagePage": 1,
+					"usage": 6
+				},
+				{
+					"vendorId": 1452,
+					"productId": 613
+				}
+			]
+		}
+	}
+}

--- a/src/ChefManager.ts
+++ b/src/ChefManager.ts
@@ -106,7 +106,10 @@ export class ChefManager {
 		const defaultSession = session.defaultSession
 
 		defaultSession.setPermissionCheckHandler((webContents, permission) => {
-			if (permission !== 'hid') return false
+			if (permission !== 'hid') {
+				// Match Electron's default permission-check behavior when no custom handler is set.
+				return permission !== 'deprecated-sync-clipboard-read'
+			}
 			if (!webContents) return false
 
 			const window = this.windowsHelper.getWindowForWebContents(webContents)

--- a/src/ChefManager.ts
+++ b/src/ChefManager.ts
@@ -1,4 +1,4 @@
-import { App, globalShortcut, dialog } from 'electron'
+import { App, globalShortcut, dialog, session } from 'electron'
 import { Logger } from './lib/logging'
 import { ConfigHelper } from './helpers/ConfigHelper'
 import { AllWindowsManager } from './helpers/AllWindowsManager'
@@ -40,6 +40,8 @@ export class ChefManager {
 
 	public onAppReady(): void {
 		this.logger.info('Initializing...')
+
+		this.setupWebHIDPermissions()
 
 		this.windowsHelper.initialize()
 
@@ -97,6 +99,62 @@ export class ChefManager {
 					})
 					.catch((e) => this.logger.error(e))
 			}
+		})
+	}
+
+	private setupWebHIDPermissions() {
+		const defaultSession = session.defaultSession
+
+		defaultSession.setPermissionCheckHandler((webContents, permission) => {
+			if (permission !== 'hid') return false
+			if (!webContents) return false
+
+			const window = this.windowsHelper.getWindowForWebContents(webContents)
+			return window?.hasAllowedWebHIDDevices() ?? false
+		})
+
+		defaultSession.setDevicePermissionHandler((details) => {
+			if (details.deviceType !== 'hid') return false
+
+			const window = this.windowsHelper.getWindowForOrigin(details.origin)
+			if (!window) return false
+
+			const device = details.device as Electron.HIDDevice
+			const allowed = window.isAllowedWebHIDDevice(device)
+
+			if (allowed) {
+				this.logger.info(
+					`Window "${window.id}": auto-approved WebHID device ${device.vendorId}:${device.productId} (${device.deviceId})`
+				)
+			} else {
+				this.logger.info(
+					`Window "${window.id}": denied WebHID device ${device.vendorId}:${device.productId} (${device.deviceId})`
+				)
+			}
+
+			return allowed
+		})
+
+		defaultSession.on('select-hid-device', (event, details, callback) => {
+			event.preventDefault()
+
+			const window = this.windowsHelper.getWindowForFrame(details.frame)
+			if (!window || !window.hasAllowedWebHIDDevices()) {
+				callback('')
+				return
+			}
+
+			const device = details.deviceList.find((entry) => window.isAllowedWebHIDDevice(entry))
+			if (!device) {
+				this.logger.info(`Window "${window.id}": no matching WebHID device in chooser, denying request`)
+				callback('')
+				return
+			}
+
+			this.logger.info(
+				`Window "${window.id}": selected WebHID device ${device.vendorId}:${device.productId} (${device.deviceId})`
+			)
+			callback(device.deviceId)
 		})
 	}
 }

--- a/src/helpers/AllWindowsManager.ts
+++ b/src/helpers/AllWindowsManager.ts
@@ -23,6 +23,7 @@ export class AllWindowsManager extends EventEmitter {
 			this.getAllWindows().forEach((w) => w.window.receiveExternalStatus(browserWindow, payload))
 		})
 	}
+
 	static GetAllWindowsManager(logger: Logger): AllWindowsManager {
 		// return singleton
 		this._singletonInstance = this._singletonInstance ?? new AllWindowsManager(logger)
@@ -36,12 +37,30 @@ export class AllWindowsManager extends EventEmitter {
 	public getWindow(id: string): WindowHelper | undefined {
 		return this.windowsHandlers[id]
 	}
+
 	public getAllWindows(): { id: string; window: WindowHelper }[] {
 		return Object.entries<WindowHelper>(this.windowsHandlers).map(([id, window]) => ({ id, window }))
 	}
+
 	public getLastFocusedWindow(): WindowHelper | undefined {
 		return this.lastFocusedWindow
 	}
+
+	public getWindowForWebContents(webContents: Electron.WebContents): WindowHelper | undefined {
+		return Object.values<WindowHelper>(this.windowsHandlers).find((window) => window.isWebContents(webContents))
+	}
+
+	public getWindowForFrame(frame: Electron.WebFrameMain | null): WindowHelper | undefined {
+		if (!frame) return undefined
+
+		const mainFrame = frame.top ?? frame
+		return Object.values<WindowHelper>(this.windowsHandlers).find((window) => window.isMainFrame(mainFrame))
+	}
+
+	public getWindowForOrigin(origin: string): WindowHelper | undefined {
+		return Object.values<WindowHelper>(this.windowsHandlers).find((window) => window.isOrigin(origin))
+	}
+
 	public getStatus(): { [index: string]: StatusObject } {
 		const status: { [index: string]: StatusObject } = {}
 

--- a/src/helpers/WindowHelper.ts
+++ b/src/helpers/WindowHelper.ts
@@ -1,6 +1,6 @@
 import { BrowserWindow, screen } from 'electron'
 import { EventEmitter } from 'events'
-import { ConfigWindow, ConfigWindowShared } from '../lib/config'
+import { ConfigWindow, ConfigWindowAllowedWebHIDDevice, ConfigWindowShared } from '../lib/config'
 import _ = require('underscore')
 import { Logger } from '../lib/logging'
 import { ReportStatusIpcPayload, StatusCode, StatusObject } from '../lib/api'
@@ -98,6 +98,40 @@ export class WindowHelper extends EventEmitter {
 	}
 	public get config(): ConfigWindow {
 		return this._config
+	}
+	public hasAllowedWebHIDDevices(): boolean {
+		return (this._config.allowedWebHIDDevices?.length ?? 0) > 0
+	}
+	public isWebContents(webContents: Electron.WebContents): boolean {
+		return this.window.webContents === webContents
+	}
+	public isMainFrame(frame: Electron.WebFrameMain | null): boolean {
+		if (!frame) return false
+
+		const mainFrame = this.window.webContents.mainFrame
+		return mainFrame.processId === frame.processId && mainFrame.routingId === frame.routingId
+	}
+	public isOrigin(origin: string): boolean {
+		const currentUrl = this.window.webContents.getURL()
+		if (!currentUrl) return false
+
+		try {
+			return new URL(currentUrl).origin === origin
+		} catch {
+			return false
+		}
+	}
+	public isAllowedWebHIDDevice(device: Electron.HIDDevice): boolean {
+		const allowedDevices = this._config.allowedWebHIDDevices ?? []
+
+		for (const allowedDevice of allowedDevices) {
+			if (!this._matchesVendorAndProduct(device, allowedDevice)) continue
+			if (!this._matchesUsageFilter(device, allowedDevice)) continue
+
+			return true
+		}
+
+		return false
 	}
 	public get url(): string | null {
 		return this._url
@@ -429,5 +463,24 @@ function setupUpdateCSS() {
 	})
 }
 setupUpdateCSS();`)
+	}
+	private _matchesVendorAndProduct(
+		device: Electron.HIDDevice,
+		allowedDevice: ConfigWindowAllowedWebHIDDevice
+	): boolean {
+		return device.vendorId === allowedDevice.vendorId && device.productId === allowedDevice.productId
+	}
+	private _matchesUsageFilter(device: Electron.HIDDevice, allowedDevice: ConfigWindowAllowedWebHIDDevice): boolean {
+		const hasUsagePageFilter = allowedDevice.usagePage !== undefined
+		const hasUsageFilter = allowedDevice.usage !== undefined
+
+		if (!hasUsagePageFilter && !hasUsageFilter) return true
+
+		return device.collections.some((collection) => {
+			const usagePageMatches = !hasUsagePageFilter || collection.usagePage === allowedDevice.usagePage
+			const usageMatches = !hasUsageFilter || collection.usage === allowedDevice.usage
+
+			return usagePageMatches && usageMatches
+		})
 	}
 }

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -12,6 +12,16 @@ export interface Config extends ConfigWindowShared {
 	/** A list of the windows to be created */
 	windows: { [id: string]: ConfigWindow }
 }
+export interface ConfigWindowAllowedWebHIDDevice {
+	/** The USB vendor ID. */
+	vendorId: number
+	/** The USB product ID. */
+	productId: number
+	/** Optional HID usage page filter. */
+	usagePage?: number
+	/** Optional HID usage filter. */
+	usage?: number
+}
 export interface ConfigWindow {
 	/** X-position of the window */
 	x: number | undefined
@@ -58,6 +68,9 @@ export interface ConfigWindow {
 
 	/** Zoom factor of the content. Default is 100 (%) */
 	zoomFactor?: number
+
+	/** A list of WebHID devices that are allowed and automatically approved for this window. */
+	allowedWebHIDDevices?: ConfigWindowAllowedWebHIDDevice[]
 }
 
 export const DEFAULT_CONFIG: Config = {
@@ -81,6 +94,7 @@ export const DEFAULT_CONFIG: Config = {
 			hideCursor: true,
 			hideScrollbar: false,
 			zoomFactor: 100,
+			allowedWebHIDDevices: [],
 		},
 	},
 }


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://sofie-automation.github.io/sofie-core//docs/for-developers/contribution-guidelines
-->

## About the Contributor

<!--
Tell us who / which organization you are representing, and how the Sofie team will be able to contact you.
Example: "This pull request is posted on behalf of the NRK."
-->

This pull request is posted on behalf of TV 2 Norge.

## Type of Contribution

This is a:

<!-- (pick one) -->

Feature

## Current Behavior

<!--
Please describe how things worked before this PR.
If it's a bug fixe: Describe the bug (what was happening?)
-->

No way to use webhid devices with Sofie Chef

## New Behavior

<!--
What is the new behavior?
-->

New `ConfigWindow` property called `allowedWebHIDDevices` is added. It allows to define webhid devices to be automatically approved in specific windows. A device in this array will not require explicit user approval when the page displayed in the window tries to access it.

## Testing Instructions

<!--
Please provide some instructions and other information for how to verify that the feature works.
Examples:
* "Do a Take for a part that contains an adlib, verify that the adlib plays out."
* "Open the Switchboard panel and toggle a route, verify that the route toggles in the GUI."
* "This feature also affects 'feature X', so that needs to be tested for regressions as well."
-->

- Connect a webhid-capable device and find a webpage that supports said device 
- Add said page as a window to the config
- Find your vendor and device ids and configure `allowedWebHIDDevices` as documented
- Save the config and verify if the device is immediately operational in the newly opened window


## Other Information

<!-- The more information you can provide, the easier the pull request will be to merge -->

## Status

<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [x] Relevant documentation (code comments, [system documentation](https://sofie-automation.github.io/sofie-core//)) has been added / updated.
