### PR TITLE
fix: share allowedWebHIDDevices per origin

### DIFF
--- a/docs/WebHID-Configuration.md
+++ b/docs/WebHID-Configuration.md
@@ -83,7 +83,9 @@ navigator.hid.getDevices().then((devices) => {
 
 3. **Scope**: Device approval is per-window. Each window can have its own allowed device list.
 
-4. **Logging**: Chef will log when devices are auto-approved or denied, making it easier to debug configuration issues.
+4. **Multiple windows sharing an origin**: If multiple windows load pages from the same URL origin (e.g. `https://example.com`), a device will be auto-approved as long as it is listed in `allowedWebHIDDevices` for _any_ of those windows — not necessarily the one actually using it.
+
+5. **Logging**: Chef will log when devices are auto-approved or denied, making it easier to debug configuration issues.
 
 ### Troubleshooting
 

--- a/src/ChefManager.ts
+++ b/src/ChefManager.ts
@@ -119,23 +119,23 @@ export class ChefManager {
 		defaultSession.setDevicePermissionHandler((details) => {
 			if (details.deviceType !== 'hid') return false
 
-			const window = this.windowsHelper.getWindowForOrigin(details.origin)
-			if (!window) return false
-
 			const device = details.device as Electron.HIDDevice
-			const allowed = window.isAllowedWebHIDDevice(device)
+			const windows = this.windowsHelper.getWindowsForOrigin(details.origin)
+			const matchingWindow = windows.find((w) => w.isAllowedWebHIDDevice(device))
 
-			if (allowed) {
+			if (matchingWindow) {
 				this.logger.info(
-					`Window "${window.id}": auto-approved WebHID device ${device.vendorId}:${device.productId} (${device.deviceId})`
+					`Origin "${details.origin}": auto-approved WebHID device ${device.vendorId}:${device.productId} (${device.deviceId}) (matched config for window "${matchingWindow.id}")`
 				)
-			} else {
-				this.logger.info(
-					`Window "${window.id}": denied WebHID device ${device.vendorId}:${device.productId} (${device.deviceId})`
-				)
+				return true
 			}
 
-			return allowed
+			if (windows.length > 0) {
+				this.logger.info(
+					`Origin "${details.origin}": denied WebHID device ${device.vendorId}:${device.productId} (${device.deviceId})`
+				)
+			}
+			return false
 		})
 
 		defaultSession.on('select-hid-device', (event, details, callback) => {

--- a/src/helpers/AllWindowsManager.ts
+++ b/src/helpers/AllWindowsManager.ts
@@ -57,8 +57,8 @@ export class AllWindowsManager extends EventEmitter {
 		return Object.values<WindowHelper>(this.windowsHandlers).find((window) => window.isMainFrame(mainFrame))
 	}
 
-	public getWindowForOrigin(origin: string): WindowHelper | undefined {
-		return Object.values<WindowHelper>(this.windowsHandlers).find((window) => window.isOrigin(origin))
+	public getWindowsForOrigin(origin: string): WindowHelper[] {
+		return Object.values<WindowHelper>(this.windowsHandlers).filter((window) => window.isOrigin(origin))
 	}
 
 	public getStatus(): { [index: string]: StatusObject } {


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://sofie-automation.github.io/sofie-core//docs/for-developers/contribution-guidelines
-->

## About the Contributor

<!--
Tell us who / which organization you are representing, and how the Sofie team will be able to contact you.
Example: "This pull request is posted on behalf of the NRK."
-->
This pull request is posted on behalf of TV 2 Norge


## Type of Contribution

This is a:

<!-- (pick one) -->

Bug fix

## Current Behavior

<!--
Please describe how things worked before this PR.
If it's a bug fixe: Describe the bug (what was happening?)
-->

It could happen that a window with `allowedWebHIDDevices` defined, would not have its device auto-approved, if another window exists in the config, with a URL from the same origin, but no `allowedWebHIDDevices`.

## New Behavior

<!--
What is the new behavior?
-->
Due to limited params of the `devicePermissionHandler` (only having access to origin really), we consider all windows of the same origin as sharing their `allowedWebHIDDevices` arrays. As documented, If multiple windows load pages from the same URL origin (e.g. `https://example.com`), a device will be auto-approved as long as it is listed in `allowedWebHIDDevices` for _any_ of those windows - not necessarily the one actually using it.

## Testing Instructions

<!--
Please provide some instructions and other information for how to verify that the feature works.
Examples:
* "Do a Take for a part that contains an adlib, verify that the adlib plays out."
* "Open the Switchboard panel and toggle a route, verify that the route toggles in the GUI."
* "This feature also affects 'feature X', so that needs to be tested for regressions as well."
-->


## Other Information

<!-- The more information you can provide, the easier the pull request will be to merge -->

## Status

<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [x] Relevant documentation (code comments, [system documentation](https://sofie-automation.github.io/sofie-core//)) has been added / updated.
